### PR TITLE
Update API use for getting OTHER address space

### DIFF
--- a/ResolveARM32SyscallsScript.java
+++ b/ResolveARM32SyscallsScript.java
@@ -32,8 +32,8 @@ import ghidra.app.util.opinion.ElfLoader;
 import ghidra.framework.Application;
 import ghidra.program.model.address.*;
 import ghidra.program.model.data.DataTypeManager;
-import ghidra.program.model.lang.BasicCompilerSpec;
 import ghidra.program.model.lang.Register;
+import ghidra.program.model.lang.SpaceNames;
 import ghidra.program.model.listing.*;
 import ghidra.program.model.mem.MemoryAccessException;
 import ghidra.program.model.pcode.PcodeOp;
@@ -119,7 +119,7 @@ public class ResolveARM32SyscallsScript extends GhidraScript {
 				return;
 			}
 			Address startAddr = currentProgram.getAddressFactory().getAddressSpace(
-				BasicCompilerSpec.OTHER_SPACE_NAME).getAddress(0x0L);
+				SpaceNames.OTHER_SPACE_NAME).getAddress(0x0L);
 			AddUninitializedMemoryBlockCmd cmd = new AddUninitializedMemoryBlockCmd(
 				SYSCALL_SPACE_NAME, null, this.getClass().getName(), startAddr,
 				SYSCALL_SPACE_LENGTH, true, true, true, false, true);


### PR DESCRIPTION
Beginning with Ghidra version 10.2 the build of the ARMv7 syscalls resolver script fails with:

```
ResolveARM32SyscallsScript.java:122: error: cannot find symbol
                BasicCompilerSpec.OTHER_SPACE_NAME).getAddress(0x0L);
                                 ^
  symbol:   variable OTHER_SPACE_NAME
  location: class ghidra.program.model.lang.BasicCompilerSpec
Note: ResolveARM32SyscallsScript.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
```

Fix this by getting `OTHER_SPACE_NAME` via `SpaceNames` instead.

Link: https://github.com/NationalSecurityAgency/ghidra/commit/311a22c038eab8181b61042ccbfceb7897f428a5